### PR TITLE
Add cronjob parameter chainability

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $crontabRepository = new CrontabRepository(new CrontabAdapter());
 
 ### Create new Job and persist it into the crontab:
 
-Suppose you want to create an new job which consists of launching the
+Suppose you want to create a new job which consists of launching the
 command "df &gt;&gt; /tmp/df.log" every day at 23:30. You can do it in
 two ways.
 
@@ -55,13 +55,7 @@ two ways.
 
     ``` {.php}
     $crontabJob = new CrontabJob();
-    $crontabJob->minutes = '30';
-    $crontabJob->hours = '23';
-    $crontabJob->dayOfMonth = '*';
-    $crontabJob->months = '*';
-    $crontabJob->dayOfWeek = '*';
-    $crontabJob->taskCommandLine = 'df >> /tmp/df.log';
-    $crontabJob->comments = 'Logging disk usage'; // Comments are persisted in the crontab
+    $crontabJob->setMinutes(30)->setHours(23)->setDayOfMonth('*')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('df >> /tmp/df.log')->setComments('Logging disk usage'); // Comments are persisted in the crontab
     ```
 
 -   From raw cron syntax string using a factory method :
@@ -87,7 +81,7 @@ is applied to the entire crontab line.
 ``` {.php}
 $results = $crontabRepository->findJobByRegex('/Logging\ disk\ usage/');
 $crontabJob = $results[0];
-$crontabJob->hours = '21';
+$crontabJob->setHours(21);
 $crontabRepository->persist();
 ```
 
@@ -144,14 +138,14 @@ calling `crontab`.
 
 ### Enable or disable a cron job
 
-You can enable or disable your cron jobs by setting the `enabled`
-attribute of a CronJob object accordingly :
+You can enable or disable your cron jobs by using the `setEnabled()`
+method of a CronJob object accordingly :
 
 ``` {.php}
-$crontabJob->enabled = false;
+$crontabJob->setEnabled(false);
 ```
 
-This will have the effect to prepend your cron job with a "\#" in your
+This will prepend your cron job with a `#` in your
 crontab when persisting it.
 
 Unit tests

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The library is composed of three classes:
 -   `CrontabRepository` is used to persist/retrieve your cron jobs.
 -   `CrontabAdapter` handles cron jobs persistance in the crontab.
 
-### Instanciate the repository:
+### Instantiate the repository:
 
 In order to work, the CrontabRepository needs an instance of
 CrontabAdapter.
@@ -55,7 +55,14 @@ two ways.
 
     ``` {.php}
     $crontabJob = new CrontabJob();
-    $crontabJob->setMinutes(30)->setHours(23)->setDayOfMonth('*')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('df >> /tmp/df.log')->setComments('Logging disk usage'); // Comments are persisted in the crontab
+    $crontabJob
+        ->setMinutes(30)
+        ->setHours(23)
+        ->setDayOfMonth('*')
+        ->setMonths('*')
+        ->setDayOfWeek('*')
+        ->setTaskCommandLine('df >> /tmp/df.log')
+        ->setComments('Logging disk usage'); // Comments are persisted in the crontab
     ```
 
 -   From raw cron syntax string using a factory method :

--- a/src/CrontabManager/CrontabJob.php
+++ b/src/CrontabManager/CrontabJob.php
@@ -20,14 +20,14 @@ namespace TiBeN\CrontabManager;
 
 /**
  * CrontabJob
- * Represent a Job of the crontab.
+ * Represents a Job of the crontab.
  * 
  * @author TiBeN
  */
 class CrontabJob
 {
     /**
-     * Tell whether the cron job is enabled or not
+     * Tells whether the cron job is enabled or not
      * This will add or not a # at the beginning of the cron line
      *
      * @var boolean
@@ -87,14 +87,248 @@ class CrontabJob
     
     /**
      * Predefined scheduling definition
-     * Shorcut définition that replace standard définition (preceded by @)
-     * possibles values : yearly, monthly, weekly, daily, hourly, reboot
-     * When a shortcut is defined, it overwrite stantard définition
+     * Shorcut definition that replaces the standard definition (preceded by @)
+     * possible values : yearly, monthly, weekly, daily, hourly, reboot
+     * When a shortcut is defined, it overwrites the stantard definition
      *
      * @var String
      */
     public $shortCut;
     
+    /* Getters and Setters */
+    
+    /**
+     * Gets the enabled status of the cron job
+     * @return Boolean
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+    
+    /**
+     * Sets the enabled status of the cron job
+     * @param Boolean $enabled
+     * @return $this
+     */
+    public function setEnabled($enabled = true) 
+    {
+        $this->enabled = $enabled;
+        return $this;
+    }
+    
+    /**
+     * Gets the number of minutes.
+     * @return Int
+     */
+    public function getMinutes()
+    {
+        return $this->minutes;
+    }
+    
+    /**
+     * Sets the number of minutes.
+     * @param Int/String $minutes
+     * @throws \InvalidArgumentException
+     * @return $this
+     */
+    public function setMinutes($minutes)
+    {
+        if (is_numeric($minutes) && ((int)$minutes < 0 || (int)$minutes > 59))
+        {
+            throw new \InvalidArgumentException(
+                'The minutes value is not valid'
+            );
+        }
+        
+        $this->minutes = $minutes;
+        return $this;
+    }
+    
+    /**
+     * Gets the number of hours.
+     * @return Int
+     */
+    public function getHours()
+    {
+        return $this->hours;
+    }
+    
+    /**
+     * Sets the number of hours.
+     * @param Int/String $hours
+     * @throws \InvalidArgumentException
+     * @return $this
+     */
+    public function setHours($hours)
+    {
+        if (is_numeric($hours) && ((int)$hours < 0 || (int)$hours > 23))
+        {
+            throw new \InvalidArgumentException(
+                'The hours value is not valid'
+            );
+        }
+        
+        $this->hours = $hours;
+        return $this;
+    }
+    
+    /**
+     * Gets the day of month.
+     * @return Int
+     */
+    public function getDayOfMonth()
+    {
+        return $this->dayOfMonth;
+    }
+    
+    /**
+     * Sets the day of month.
+     * @param Int/String $dayOfMonth
+     * @throws \InvalidArgumentException
+     * @return $this
+     */
+    public function setDayOfMonth($dayOfMonth)
+    {
+        if (is_numeric($dayOfMonth) && ((int)$dayOfMonth < 1 || (int)$dayOfMonth > 31))
+        {
+            throw new \InvalidArgumentException(
+                'The day of month is not valid'
+            );
+        }
+        
+        $this->dayOfMonth = $dayOfMonth;
+        return $this;
+    }
+    
+        /**
+     * Gets the month number.
+     * @return Int
+     */
+    public function getMonths()
+    {
+        return $this->months;
+    }
+    
+    /**
+     * Sets the month number.
+     * @param Int/String $months
+     * @throws \InvalidArgumentException
+     * @return $this
+     */
+    public function setMonths($months)
+    {
+        if (is_numeric($months) && ((int)$months < 1 || (int)$months > 12))
+        {
+            throw new \InvalidArgumentException(
+                'The month value is not valid'
+            );
+        }
+        
+        $this->months = $months;
+        return $this;
+    }
+    
+        /**
+     * Gets the day of week.
+     * @return Int
+     */
+    public function getDayOfWeek()
+    {
+        return $this->dayOfWeek;
+    }
+    
+    /**
+     * Sets the day of week.
+     * @param Int/String $dayOfWeek
+     * @throws \InvalidArgumentException
+     * @return $this
+     */
+    public function setDayOfWeek($dayOfWeek)
+    {
+        // 0 and 7 are both valid for Sunday
+        if (is_numeric($dayOfWeek) && ((int)$dayOfWeek < 0 || (int)$dayOfWeek > 7))
+        {
+            throw new \InvalidArgumentException(
+                'The day of week is not valid'
+            );
+        }
+        
+        $this->dayOfWeek = $dayOfWeek;
+        return $this;
+    }
+    
+    /**
+     * Gets the task command line.
+     * @return String
+     */
+    public function getTaskCommandLine()
+    {
+        return $this->taskCommandLine;
+    }
+    
+    /**
+     * Sets the task command line.
+     * @param String $taskCommandLine
+     * @return $this
+     */
+    public function setTaskCommandLine($taskCommandLine)
+    {
+        $this->taskCommandLine = $taskCommandLine;
+        return $this;
+    }
+    
+    /**
+     * Gets the job comments.
+     * @return String
+     */
+    public function getComments()
+    {
+        return $this->comments;
+    }
+    
+    /**
+     * Sets the optional job comments.
+     * @param String $comments
+     * @return $this
+     */
+    public function setComments($comments)
+    {
+        $this->comments = $comments;
+        return $this;
+    }
+    
+    /**
+     * Gets the time shortcut.
+     * @return String
+     */
+    public function getShortCut()
+    {
+        return $this->shortCut;
+    }
+    
+    /**
+     * Sets the time shortcut.
+     * @param String $shortCut
+     * @throws \InvalidArgumentException
+     * @return $this
+     */
+    public function setShortCut($shortCut)
+    {
+        // @annually is the same as @yearly, and @midnight is the same as @daily
+        $possibleValues = array(
+            'yearly', 'annually', 'monthly', 'weekly', 'daily', 'midnight', 'hourly', 'reboot'
+        );
+        if (!in_array($shortCut, $possibleValues)) {
+            throw new \InvalidArgumentException(
+                'The shortcut is not valid.'
+            );
+        }
+        
+        $this->shortCut = $shortCut;
+        return $this;
+    }
+
     /**
      * Factory method to create a CrontabJob from a crontab line.
      *
@@ -113,7 +347,7 @@ class CrontabJob
 
         if (!preg_match($crontabLineRegex, $crontabLine, $matches)) {
             throw new \InvalidArgumentException(
-                'Crontab line not well formated then can\'t be parsed'
+                'Crontab line not well formatted, so it can\'t be parsed'
             );
         }
 
@@ -121,24 +355,20 @@ class CrontabJob
         $crontabJob = new self();
       
         if (!empty($matches[1])) {
-            $crontabJob->enabled = false;
+            $crontabJob->setEnabled(false);
         }
 
         if (!empty($matches)) {
-            $crontabJob->minutes = $matches[3];
-            $crontabJob->hours = $matches[4];
-            $crontabJob->dayOfMonth = $matches[5];
-            $crontabJob->months = $matches[6];
-            $crontabJob->dayOfWeek = $matches[7];
+            $crontabJob->setMinutes($matches[3])->setHours($matches[4])->setDayOfMonth($matches[5])->setMonths($matches[6])->setDayOfWeek($matches[7]);
         }
         
         if (!empty($matches[8])) {
-            $crontabJob->shortCut = $matches[9];
+            $crontabJob->setShortCut($matches[9]);
         }
         
-        $crontabJob->taskCommandLine = $matches[10];
+        $crontabJob->setTaskCommandLine($matches[10]);
         if (!empty($matches[12])) {
-            $crontabJob->comments = $matches[12];
+            $crontabJob->setComments($matches[12]);
         }
         
         return $crontabJob;
@@ -156,7 +386,7 @@ class CrontabJob
         // Check if job has a task command line
         if (!isset($this->taskCommandLine) || empty($this->taskCommandLine)) {
             throw new \InvalidArgumentException(
-                'CrontabJob contain\'s no task command line'
+                'CrontabJob contains no task command line'
             );
         }
         

--- a/src/CrontabManager/CrontabJob.php
+++ b/src/CrontabManager/CrontabJob.php
@@ -359,7 +359,12 @@ class CrontabJob
         }
 
         if (!empty($matches)) {
-            $crontabJob->setMinutes($matches[3])->setHours($matches[4])->setDayOfMonth($matches[5])->setMonths($matches[6])->setDayOfWeek($matches[7]);
+            $crontabJob
+                ->setMinutes($matches[3])
+                ->setHours($matches[4])
+                ->setDayOfMonth($matches[5])
+                ->setMonths($matches[6])
+                ->setDayOfWeek($matches[7]);
         }
         
         if (!empty($matches[8])) {

--- a/src/CrontabManager/CrontabRepository.php
+++ b/src/CrontabManager/CrontabRepository.php
@@ -108,7 +108,7 @@ class CrontabRepository
     }
     
     /**
-     * Add an new CrontabJob in the connected crontab
+     * Add a new CrontabJob in the connected crontab
      *
      * @param CrontabJob $crontabJob
      */
@@ -124,7 +124,7 @@ class CrontabRepository
     }
 
     /**
-     * Remove a CrontabJob in the connected crontab
+     * Remove a CrontabJob from the connected crontab
      *
      * @param CrontabJob $crontabJob
      */

--- a/tests/CrontabManager/Tests/CrontabJobTest.php
+++ b/tests/CrontabManager/Tests/CrontabJobTest.php
@@ -43,45 +43,105 @@ class CrontabJobTest extends \PHPUnit\Framework\TestCase
         $crontabLines = array();
         
         $crontabJob = new CrontabJob();
-        $crontabJob->setEnabled(true)->setMinutes(30)->setHours(23)->setDayOfMonth('*')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('df >> /tmp/df.log');
+        $crontabJob
+            ->setEnabled(true)
+            ->setMinutes(30)
+            ->setHours(23)
+            ->setDayOfMonth('*')
+            ->setMonths('*')
+            ->setDayOfWeek('*')
+            ->setTaskCommandLine('df >> /tmp/df.log');
         $crontabLines[] = array('30 23 * * * df >> /tmp/df.log', $crontabJob);
         
         $crontabJob = new CrontabJob();
-        $crontabJob->setEnabled(true)->setMinutes(12)->setHours(10)->setDayOfMonth('2-5')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('df >> /tmp/df.log');
+        $crontabJob
+            ->setEnabled(true)
+            ->setMinutes(12)
+            ->setHours(10)
+            ->setDayOfMonth('2-5')
+            ->setMonths('*')
+            ->setDayOfWeek('*')
+            ->setTaskCommandLine('df >> /tmp/df.log');
         $crontabLines[] = array('12 10 2-5 * * df >> /tmp/df.log', $crontabJob);
         
         $crontabJob = new CrontabJob();
-        $crontabJob->setEnabled(true)->setMinutes(59)->setHours(23)->setDayOfMonth('*/2')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('df >> /tmp/df.log');
+        $crontabJob
+            ->setEnabled(true)
+            ->setMinutes(59)
+            ->setHours(23)
+            ->setDayOfMonth('*/2')
+            ->setMonths('*')
+            ->setDayOfWeek('*')
+            ->setTaskCommandLine('df >> /tmp/df.log');
         $crontabLines[] = array('59 23 */2 * * df >> /tmp/df.log', $crontabJob);
         
         $crontabJob = new CrontabJob();
-        $crontabJob->setEnabled(true)->setMinutes(0)->setHours(0)->setDayOfMonth('25-31')->setMonths('1,3,5,7,8,10,12')->setDayOfWeek(0)->setTaskCommandLine('my-script.sh');
+        $crontabJob
+            ->setEnabled(true)
+            ->setMinutes(0)
+            ->setHours(0)
+            ->setDayOfMonth('25-31')
+            ->setMonths('1,3,5,7,8,10,12')
+            ->setDayOfWeek(0)
+            ->setTaskCommandLine('my-script.sh');
         $crontabLines[] = array('0 0 25-31 1,3,5,7,8,10,12 0 my-script.sh', $crontabJob);
         
         /* space at start test case */
         $crontabJob = new CrontabJob();
-        $crontabJob->setEnabled(true)->setMinutes(0)->setHours('*')->setDayOfMonth('*/2')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('my-script.sh')->setComments('commentaire blablabla');
+        $crontabJob
+            ->setEnabled(true)
+            ->setMinutes(0)
+            ->setHours('*')
+            ->setDayOfMonth('*/2')
+            ->setMonths('*')
+            ->setDayOfWeek('*')
+            ->setTaskCommandLine('my-script.sh')
+            ->setComments('commentaire blablabla');
         $crontabLines[] = array(' 0 * */2 * * my-script.sh #commentaire blablabla', $crontabJob);
 
         /* Tab or spaces test case */
         $crontabJob = new CrontabJob();
-        $crontabJob->setEnabled(true)->setMinutes(0)->setHours('*')->setDayOfMonth('*/2')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('my-script.sh')->setComments('commentaire blablabla');
+        $crontabJob
+            ->setEnabled(true)
+            ->setMinutes(0)
+            ->setHours('*')
+            ->setDayOfMonth('*/2')
+            ->setMonths('*')
+            ->setDayOfWeek('*')
+            ->setTaskCommandLine('my-script.sh')
+            ->setComments('commentaire blablabla');
         $crontabLines[] = array('0  *    */2      *       *      my-script.sh #commentaire blablabla', $crontabJob);
         
         /* Cron shortcut test case */
         $crontabJob = new CrontabJob();
-        $crontabJob->setEnabled(true)->setShortCut('daily')->setTaskCommandLine('my-script.sh');
+        $crontabJob
+            ->setEnabled(true)
+            ->setShortCut('daily')
+            ->setTaskCommandLine('my-script.sh');
         $crontabLines[] = array('@daily my-script.sh', $crontabJob);
         
         /* Disabled cron test case - without spaces */
         $crontabJob = new CrontabJob();
-        $crontabJob->setEnabled(false)->setMinutes(30)->setHours(23)->setDayOfMonth('*')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('df >> /tmp/df.log');
+        $crontabJob
+            ->setEnabled(false)
+            ->setMinutes(30)
+            ->setHours(23)
+            ->setDayOfMonth('*')
+            ->setMonths('*')
+            ->setDayOfWeek('*')
+            ->setTaskCommandLine('df >> /tmp/df.log');
         $crontabLines[] = array('#30 23 * * * df >> /tmp/df.log', $crontabJob);
 
         /* Disabled cron test case - with spaces */
         $crontabJob = new CrontabJob();
-        $crontabJob->enabled = false;
-        $crontabJob->setEnabled(false)->setMinutes(30)->setHours(23)->setDayOfMonth('*')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('df >> /tmp/df.log');
+        $crontabJob
+            ->setEnabled(false)
+            ->setMinutes(30)
+            ->setHours(23)
+            ->setDayOfMonth('*')
+            ->setMonths('*')
+            ->setDayOfWeek('*')
+            ->setTaskCommandLine('df >> /tmp/df.log');
         $crontabLines[] = array('#   30 23 * * * df >> /tmp/df.log', $crontabJob);
 
         return $crontabLines;
@@ -91,18 +151,27 @@ class CrontabJobTest extends \PHPUnit\Framework\TestCase
     {
         /* Well formatted crontab line */
         $crontabJob = new CrontabJob();
-        $crontabJob->setMinutes(30)->setHours(23)->setTaskCommandLine('df >> /tmp/df.log');
+        $crontabJob
+            ->setMinutes(30)
+            ->setHours(23)
+            ->setTaskCommandLine('df >> /tmp/df.log');
         $this->assertEquals('30 23 * * * df >> /tmp/df.log', $crontabJob->formatCrontabLine());
         $crontabJob = new CrontabJob();
         
         /* Crontab line formatted with a shortcut */
         $crontab = new CrontabJob();
-        $crontabJob->setShortCut('reboot')->setTaskCommandLine('echo "youpi"');
+        $crontabJob
+            ->setShortCut('reboot')
+            ->setTaskCommandLine('echo "youpi"');
         $this->assertEquals('@reboot echo "youpi"', $crontabJob->formatCrontabLine());
         
         /* crontab line with comments */
         $crontabJob = new CrontabJob();
-        $crontabJob->setMinutes(30)->setHours(23)->setTaskCommandLine('df >> /tmp/df.log')->setComments('This job is commented');
+        $crontabJob
+            ->setMinutes(30)
+            ->setHours(23)
+            ->setTaskCommandLine('df >> /tmp/df.log')
+            ->setComments('This job is commented');
         $this->assertEquals(
             '30 23 * * * df >> /tmp/df.log #This job is commented', 
             $crontabJob->formatCrontabLine()
@@ -110,7 +179,12 @@ class CrontabJobTest extends \PHPUnit\Framework\TestCase
 
         /* disabled crontab line */
         $crontabJob = new CrontabJob();
-        $crontabJob->setEnabled(false)->setMinutes(30)->setHours(23)->setTaskCommandLine('df >> /tmp/df.log')->setComments('This job is commented');
+        $crontabJob
+            ->setEnabled(false)
+            ->setMinutes(30)
+            ->setHours(23)
+            ->setTaskCommandLine('df >> /tmp/df.log')
+            ->setComments('This job is commented');
         $this->assertEquals(
             '#30 23 * * * df >> /tmp/df.log #This job is commented', 
             $crontabJob->formatCrontabLine()
@@ -152,20 +226,31 @@ class CrontabJobTest extends \PHPUnit\Framework\TestCase
     public function testNoTaskSetException()
     {
         $crontabJob = new CrontabJob();
-        $crontabJob->setMinutes(30)->setHours(23)->formatCrontabLine();
+        $crontabJob
+            ->setMinutes(30)
+            ->setHours(23)
+            ->formatCrontabLine();
     }
     
     public function testSettersWithValidValues()
     {
         $crontabJob = new CrontabJob();
-        $crontabJob->setEnabled(true)->setMinutes(50)->setHours(20)->setDayOfMonth(3)->setMonths(4)->setDayOfWeek('*')->setTaskCommandLine('myscript.sh')->setComments('My recurring task');
+        $crontabJob
+            ->setEnabled(true)
+            ->setMinutes(50)
+            ->setHours(20)
+            ->setDayOfMonth(3)
+            ->setMonths(4)
+            ->setDayOfWeek('*')
+            ->setTaskCommandLine('myScript.sh')
+            ->setComments('My recurring task');
         $this->assertTrue($crontabJob->isEnabled());
         $this->assertEquals($crontabJob->getMinutes(), 50);
         $this->assertEquals($crontabJob->getHours(), 20);
         $this->assertEquals($crontabJob->getDayOfMonth(), 3);
         $this->assertEquals($crontabJob->getMonths(), 4);
         $this->assertEquals($crontabJob->getDayOfWeek(), '*');
-        $this->assertEquals($crontabJob->getTaskCommandLine(), 'myscript.sh');
+        $this->assertEquals($crontabJob->getTaskCommandLine(), 'myScript.sh');
         $this->assertEquals($crontabJob->getComments(), 'My recurring task');
     }
     

--- a/tests/CrontabManager/Tests/CrontabJobTest.php
+++ b/tests/CrontabManager/Tests/CrontabJobTest.php
@@ -43,96 +43,45 @@ class CrontabJobTest extends \PHPUnit\Framework\TestCase
         $crontabLines = array();
         
         $crontabJob = new CrontabJob();
-        $crontabJob->enabled = true;
-        $crontabJob->minutes = '30';
-        $crontabJob->hours = '23';
-        $crontabJob->dayOfMonth = '*';
-        $crontabJob->months = '*';
-        $crontabJob->dayOfWeek = '*';
-        $crontabJob->taskCommandLine = 'df >> /tmp/df.log';
+        $crontabJob->setEnabled(true)->setMinutes(30)->setHours(23)->setDayOfMonth('*')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('df >> /tmp/df.log');
         $crontabLines[] = array('30 23 * * * df >> /tmp/df.log', $crontabJob);
         
         $crontabJob = new CrontabJob();
-        $crontabJob->enabled = true;
-        $crontabJob->minutes = '12';
-        $crontabJob->hours = '10';
-        $crontabJob->dayOfMonth = '2-5';
-        $crontabJob->months = '*';
-        $crontabJob->dayOfWeek = '*';
-        $crontabJob->taskCommandLine = 'df >> /tmp/df.log';
+        $crontabJob->setEnabled(true)->setMinutes(12)->setHours(10)->setDayOfMonth('2-5')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('df >> /tmp/df.log');
         $crontabLines[] = array('12 10 2-5 * * df >> /tmp/df.log', $crontabJob);
         
         $crontabJob = new CrontabJob();
-        $crontabJob->enabled = true;
-        $crontabJob->minutes = '59';
-        $crontabJob->hours = '23';
-        $crontabJob->dayOfMonth = '*/2';
-        $crontabJob->months = '*';
-        $crontabJob->dayOfWeek = '*';
-        $crontabJob->taskCommandLine = 'df >> /tmp/df.log';
+        $crontabJob->setEnabled(true)->setMinutes(59)->setHours(23)->setDayOfMonth('*/2')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('df >> /tmp/df.log');
         $crontabLines[] = array('59 23 */2 * * df >> /tmp/df.log', $crontabJob);
         
         $crontabJob = new CrontabJob();
-        $crontabJob->enabled = true;
-        $crontabJob->minutes = '0';
-        $crontabJob->hours = '0';
-        $crontabJob->dayOfMonth = '25-31';
-        $crontabJob->months = '1,3,5,7,8,10,12';
-        $crontabJob->dayOfWeek = '0';
-        $crontabJob->taskCommandLine = 'my-script.sh';
+        $crontabJob->setEnabled(true)->setMinutes(0)->setHours(0)->setDayOfMonth('25-31')->setMonths('1,3,5,7,8,10,12')->setDayOfWeek(0)->setTaskCommandLine('my-script.sh');
         $crontabLines[] = array('0 0 25-31 1,3,5,7,8,10,12 0 my-script.sh', $crontabJob);
         
         /* space at start test case */
         $crontabJob = new CrontabJob();
-        $crontabJob->enabled = true;
-        $crontabJob->minutes = '0';
-        $crontabJob->hours = '*';
-        $crontabJob->dayOfMonth = '*/2';
-        $crontabJob->months = '*';
-        $crontabJob->dayOfWeek = '*';
-        $crontabJob->taskCommandLine = 'my-script.sh';
-        $crontabJob->comments = 'commentaire blablabla';
+        $crontabJob->setEnabled(true)->setMinutes(0)->setHours('*')->setDayOfMonth('*/2')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('my-script.sh')->setComments('commentaire blablabla');
         $crontabLines[] = array(' 0 * */2 * * my-script.sh #commentaire blablabla', $crontabJob);
 
         /* Tab or spaces test case */
         $crontabJob = new CrontabJob();
-        $crontabJob->enabled = true;
-        $crontabJob->minutes = '0';
-        $crontabJob->hours = '*';
-        $crontabJob->dayOfMonth = '*/2';
-        $crontabJob->months = '*';
-        $crontabJob->dayOfWeek = '*';
-        $crontabJob->taskCommandLine = 'my-script.sh';
-        $crontabJob->comments = 'commentaire blablabla';
+        $crontabJob->setEnabled(true)->setMinutes(0)->setHours('*')->setDayOfMonth('*/2')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('my-script.sh')->setComments('commentaire blablabla');
         $crontabLines[] = array('0  *    */2      *       *      my-script.sh #commentaire blablabla', $crontabJob);
         
         /* Cron shortcut test case */
         $crontabJob = new CrontabJob();
-        $crontabJob->enabled = true;
-        $crontabJob->shortCut = 'daily';
-        $crontabJob->taskCommandLine = 'my-script.sh';
+        $crontabJob->setEnabled(true)->setShortCut('daily')->setTaskCommandLine('my-script.sh');
         $crontabLines[] = array('@daily my-script.sh', $crontabJob);
         
         /* Disabled cron test case - without spaces */
         $crontabJob = new CrontabJob();
-        $crontabJob->enabled = false;
-        $crontabJob->minutes = '30';
-        $crontabJob->hours = '23';
-        $crontabJob->dayOfMonth = '*';
-        $crontabJob->months = '*';
-        $crontabJob->dayOfWeek = '*';
-        $crontabJob->taskCommandLine = 'df >> /tmp/df.log';
+        $crontabJob->setEnabled(false)->setMinutes(30)->setHours(23)->setDayOfMonth('*')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('df >> /tmp/df.log');
         $crontabLines[] = array('#30 23 * * * df >> /tmp/df.log', $crontabJob);
 
         /* Disabled cron test case - with spaces */
         $crontabJob = new CrontabJob();
         $crontabJob->enabled = false;
-        $crontabJob->minutes = '30';
-        $crontabJob->hours = '23';
-        $crontabJob->dayOfMonth = '*';
-        $crontabJob->months = '*';
-        $crontabJob->dayOfWeek = '*';
-        $crontabJob->taskCommandLine = 'df >> /tmp/df.log';
+        $crontabJob->setEnabled(false)->setMinutes(30)->setHours(23)->setDayOfMonth('*')->setMonths('*')->setDayOfWeek('*')->setTaskCommandLine('df >> /tmp/df.log');
         $crontabLines[] = array('#   30 23 * * * df >> /tmp/df.log', $crontabJob);
 
         return $crontabLines;
@@ -140,26 +89,20 @@ class CrontabJobTest extends \PHPUnit\Framework\TestCase
     
     public function testFormatCrontabLine()
     {
-        /* Normal formated crontab line */
+        /* Well formatted crontab line */
         $crontabJob = new CrontabJob();
-        $crontabJob->minutes = '30';
-        $crontabJob->hours = '23';
-        $crontabJob->taskCommandLine = 'df >> /tmp/df.log';
+        $crontabJob->setMinutes(30)->setHours(23)->setTaskCommandLine('df >> /tmp/df.log');
         $this->assertEquals('30 23 * * * df >> /tmp/df.log', $crontabJob->formatCrontabLine());
         $crontabJob = new CrontabJob();
         
-        /* Shortcut formated crontab line */
+        /* Crontab line formatted with a shortcut */
         $crontab = new CrontabJob();
-        $crontabJob->shortCut = 'reboot';
-        $crontabJob->taskCommandLine = 'echo "youpi"';
+        $crontabJob->setShortCut('reboot')->setTaskCommandLine('echo "youpi"');
         $this->assertEquals('@reboot echo "youpi"', $crontabJob->formatCrontabLine());
         
         /* crontab line with comments */
         $crontabJob = new CrontabJob();
-        $crontabJob->minutes = '30';
-        $crontabJob->hours = '23';
-        $crontabJob->taskCommandLine = 'df >> /tmp/df.log';
-        $crontabJob->comments = 'This job is commented';
+        $crontabJob->setMinutes(30)->setHours(23)->setTaskCommandLine('df >> /tmp/df.log')->setComments('This job is commented');
         $this->assertEquals(
             '30 23 * * * df >> /tmp/df.log #This job is commented', 
             $crontabJob->formatCrontabLine()
@@ -167,11 +110,7 @@ class CrontabJobTest extends \PHPUnit\Framework\TestCase
 
         /* disabled crontab line */
         $crontabJob = new CrontabJob();
-        $crontabJob->enabled = false;
-        $crontabJob->minutes = '30';
-        $crontabJob->hours = '23';
-        $crontabJob->taskCommandLine = 'df >> /tmp/df.log';
-        $crontabJob->comments = 'This job is commented';
+        $crontabJob->setEnabled(false)->setMinutes(30)->setHours(23)->setTaskCommandLine('df >> /tmp/df.log')->setComments('This job is commented');
         $this->assertEquals(
             '#30 23 * * * df >> /tmp/df.log #This job is commented', 
             $crontabJob->formatCrontabLine()
@@ -181,40 +120,102 @@ class CrontabJobTest extends \PHPUnit\Framework\TestCase
     
     /**
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Crontab line not well formated then can't be parsed
+     * @expectedExceptionMessage Crontab line not well formatted, so it can't be parsed
      */
-    public function testCrontabLineNotWellFormatedNotEnoughStars()
+    public function testCrontabLineNotWellFormattedNotEnoughStars()
     {
         CrontabJob::createFromCrontabLine('* * 15 * youpi');
     }
 
     /**
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Crontab line not well formated then can't be parsed
+     * @expectedExceptionMessage Crontab line not well formatted, so it can't be parsed
      */
-    public function testCrontabLineNotWellFormatedShortcutWithoutArobase()
+    public function testCrontabLineNotWellFormattedShortcutWithoutAtSign()
     {
         CrontabJob::createFromCrontabLine('daily youpi');
     }
 
     /**
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Crontab line not well formated then can't be parsed
+     * @expectedExceptionMessage Crontab line not well formatted, so it can't be parsed
      */
-    public function testCrontabLineNotWellFormatedUnknownShortcut()
+    public function testCrontabLineNotWellFormattedUnknownShortcut()
     {
         CrontabJob::createFromCrontabLine('@maintenant youpi');
     }
     
     /**
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage CrontabJob contain's no task command line
+     * @expectedExceptionMessage CrontabJob contains no task command line
      */
     public function testNoTaskSetException()
     {
         $crontabJob = new CrontabJob();
-        $crontabJob->minutes = '30';
-        $crontabJob->hours = '23';
-        $crontabJob->formatCrontabLine();
+        $crontabJob->setMinutes(30)->setHours(23)->formatCrontabLine();
+    }
+    
+    public function testSettersWithValidValues()
+    {
+        $crontabJob = new CrontabJob();
+        $crontabJob->setEnabled(true)->setMinutes(50)->setHours(20)->setDayOfMonth(3)->setMonths(4)->setDayOfWeek('*')->setTaskCommandLine('myscript.sh')->setComments('My recurring task');
+        $this->assertTrue($crontabJob->isEnabled());
+        $this->assertEquals($crontabJob->getMinutes(), 50);
+        $this->assertEquals($crontabJob->getHours(), 20);
+        $this->assertEquals($crontabJob->getDayOfMonth(), 3);
+        $this->assertEquals($crontabJob->getMonths(), 4);
+        $this->assertEquals($crontabJob->getDayOfWeek(), '*');
+        $this->assertEquals($crontabJob->getTaskCommandLine(), 'myscript.sh');
+        $this->assertEquals($crontabJob->getComments(), 'My recurring task');
+    }
+    
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The minutes value is not valid
+     */
+    public function testInvalidMinutes()
+    {
+        $crontabJob = new CrontabJob();
+        $crontabJob->setMinutes(65);
+    }
+    
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The hours value is not valid
+     */
+    public function testInvalidHours()
+    {
+        $crontabJob = new CrontabJob();
+        $crontabJob->setHours(27);
+    }
+    
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The day of month is not valid
+     */
+    public function testInvalidDayOfMonth()
+    {
+        $crontabJob = new CrontabJob();
+        $crontabJob->setDayOfMonth(34);
+    }
+    
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The month value is not valid
+     */
+    public function testInvalidMonth()
+    {
+        $crontabJob = new CrontabJob();
+        $crontabJob->setMonths(14);
+    }
+    
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The day of week is not valid
+     */
+    public function testInvalidDayOfWeek()
+    {
+        $crontabJob = new CrontabJob();
+        $crontabJob->setDayOfWeek(9);
     }
 }


### PR DESCRIPTION
Fixes #9. Made the following changes:

- Added getters and setters for better OOP paradigm and parameters chainability
- In setters added some validation rules. Note: not everything is implemented yet, should be discussed (for example, months and days abbreviations are not validated)
- Changed tests and added new tests accordingly
- Fixed some spelling errors in English, including in method names (only in the tests!)
- Changed Readme to reflect new functionality
- The new functionality should not break anything, if it does, please chime in.