### PR TITLE
Use a CrontabAdapterInterface instead of the class

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,13 @@ $crontabJob->setEnabled(false);
 This will prepend your cron job with a `#` in your
 crontab when persisting it.
 
+### Write your own adapter
+Additionally, if you cannot read another user's crontabs or if you are on a distributed architecture where crons are not 
+run on the machine executing the jobs, you can create any other Adapter for your architecture 
+by implementing the `CrontabAdapterInterface`.
+
+You can then instantiate the `CrontabRepository` with your adapter.
+
 Unit tests
 ----------
 

--- a/src/CrontabManager/CrontabAdapter.php
+++ b/src/CrontabManager/CrontabAdapter.php
@@ -24,7 +24,7 @@ namespace TiBeN\CrontabManager;
  *
  * @author TiBeN
  */
-class CrontabAdapter
+class CrontabAdapter implements CrontabAdapterInterface
 {
     private $userName;
     

--- a/src/CrontabManager/CrontabAdapterInterface.php
+++ b/src/CrontabManager/CrontabAdapterInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright 2013 Benjamin Legendre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace TiBeN\CrontabManager;
+
+/**
+ * Crontab adapter. 
+ * Retrieve and write cron jobs data using the "crontab" command line.
+ *
+ * @author TiBeN
+ */
+interface CrontabAdapterInterface
+{
+
+    /**
+     * Read the crontab and return
+     * raw data
+     *
+     * @return String $output the crontab raw data
+     */
+    public function readCrontab();
+
+    /**
+     * Write the raw crontab data to the crontab.
+     *
+     * @param String $crontabRawData
+     */
+    public function writeCrontab($crontabRawData);
+}

--- a/src/CrontabManager/CrontabRepository.php
+++ b/src/CrontabManager/CrontabRepository.php
@@ -55,7 +55,7 @@ class CrontabRepository
      *
      * @param CrontabAdapter $crontabAdapter
      */
-    public function __construct(CrontabAdapter $crontabAdapter)
+    public function __construct(CrontabAdapterInterface $crontabAdapter)
     {
         $this->crontabAdapter = $crontabAdapter;
         $this->readCrontab();


### PR DESCRIPTION
This PR allows users to create adapters in their code, i.e. by providing a textfile or reading an API depending on their architectures.